### PR TITLE
Version 2.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 See [DocuSign Support Center](https://support.docusign.com/en/releasenotes/) for Product Release Notes.
 
 
+## [v2.0.0] - Admin API v2.1-1.1.0 - 2023-01-23
+### Breaking 
+- Deprecating Node versions <12
+### Security
+- Update jsonwebtoken package to 9.0.0 addressing CVE-2022-23529
+
+### Changed
+- Added support for version v2.1-1.1.0 of the DocuSign Admin API.
+- Updated the SDK release version.
+
 ## [v1.1.0] - Admin API v2.1-1.1.0 - 2022-04-26
 ### Changed
 - Added support for version v2.1-1.1.0 of the DocuSign Admin API.

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ The DocuSign Admin Node Client is licensed under the [MIT License](https://githu
 
 [npm-image]: https://img.shields.io/npm/v/docusign-admin.svg?style=flat
 [npm-url]: https://npmjs.org/package/docusign-admin
-[downloads-image]: https://img.shields.io/npm/dm/docusign-orgadmin.svg?style=flat
+[downloads-image]: https://img.shields.io/npm/dm/docusign-admin.svg?style=flat
 [downloads-url]: https://npmjs.org/package/docusign-admin
 [travis-image]: https://img.shields.io/travis/docusign/docusign-admin-node-client.svg?style=flat
 [travis-url]: https://travis-ci.org/docusign/docusign-admin-node-client

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ This client has the following external dependencies:
 ### Optional:
 
 - Async v2.6.2
-- Jsonwebtoken v8.2.0
+- Jsonwebtoken v9.0.0
 - Passport-oauth2
 - Path
 
@@ -77,9 +77,9 @@ The DocuSign Admin Node Client is licensed under the [MIT License](https://githu
 
 [npm-image]: https://img.shields.io/npm/v/docusign-admin.svg?style=flat
 [npm-url]: https://npmjs.org/package/docusign-admin
-[downloads-image]: https://img.shields.io/npm/dm/docusign-admin.svg?style=flat
+[downloads-image]: https://img.shields.io/npm/dm/docusign-orgadmin.svg?style=flat
 [downloads-url]: https://npmjs.org/package/docusign-admin
 [travis-image]: https://img.shields.io/travis/docusign/docusign-admin-node-client.svg?style=flat
 [travis-url]: https://travis-ci.org/docusign/docusign-admin-node-client
 [coveralls-image]: https://coveralls.io/repos/github/docusign/docusign-admin-node-client/badge.svg?branch=master
-[coveralls-url]: https://coveralls.io/github/docusign/docusign-odmin-node-client?branch=master
+[coveralls-url]: https://coveralls.io/github/docusign/docusign-admin-node-client?branch=master

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docusign-admin",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "The DocuSign Admin API enables you to automate user management with your existing systems while ensuring governance and compliance.",
   "license": "MIT",
   "main": "src/index.js",
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "csv-stringify": "^1.0.0",
-    "jsonwebtoken": "8.2.0",
+    "jsonwebtoken": "^9.0.0",
     "passport-oauth2": "^1.6.1",
     "safe-buffer": "^5.1.2",
     "superagent": "3.8.2"


### PR DESCRIPTION
### Breaking 
- Deprecating Node versions <12
### Security
- Update jsonwebtoken package to 9.0.0 addressing CVE-2022-23529

### Changed
- Added support for version v2.1-1.1.0 of the DocuSign Admin API.
- Updated the SDK release version.
